### PR TITLE
fix for new Windows 10 miseq runfolder layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "digestiflow-cli"
-version = "0.5.7"
+version = "0.5.9"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "digestiflow-cli"
-version = "0.5.7"
-authors = ["Manuel Holtgrewe <manuel.holtgrewe@bihealth.de>"]
+version = "0.5.9"
+authors = ["Manuel Holtgrewe <manuel.holtgrewe@bih-charite.de>", "Marten Jäger <marten.jaeger@bih-charite.de>"]
 
 [dependencies]
 # Elegant error handling

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Digestiflow CLI Client Changelog
 
+## v0.5.9
+
+- Adding fix for new Windows10 bases MiSeq output
+
 ## v0.5.8
 
 - Allowing "failed" flowcell to become complete to take care of some corner cases.

--- a/src/ingest/mod.rs
+++ b/src/ingest/mod.rs
@@ -336,7 +336,8 @@ fn process_folder(
 
     let param_pkg = {
         let filename = match folder_layout {
-            FolderLayout::MiSeq => "runParameters.xml",
+            FolderLayout::MiSeqDep => "runParameters.xml",
+            FolderLayout::MiSeq => "RunParameters.xml",
             FolderLayout::MiniSeq => "RunParameters.xml",
             FolderLayout::HiSeqX => "RunParameters.xml",
             FolderLayout::NovaSeq => "RunParameters.xml",


### PR DESCRIPTION
old: runParameters.xml
new: RunParameters.xml

renamed old MiSeq structures etc. to miseqdep (deprecated)